### PR TITLE
Use safe_load to load configuration

### DIFF
--- a/workflows/templates/thamos-advise-template.yaml
+++ b/workflows/templates/thamos-advise-template.yaml
@@ -55,7 +55,7 @@ spec:
           thoth_yaml = {}
           if thoth_conf_file_path.exists():
             with open(thoth_conf_file_path, 'r') as yaml_file:
-              thoth_yaml = yaml.load(yaml_file, Loader=yaml.FullLoader)
+              thoth_yaml = yaml.safe_load(yaml_file)
           else:
             thoth_yaml = {
                 'host': '{{inputs.parameters.THOTH_HOST}}',


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/argo/staging/script", line 22, in <module>
    thoth_yaml = yaml.load(yaml_file, Loader=yaml.FullLoader)
AttributeError: module 'yaml' has no attribute 'FullLoader'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

