### PR TITLE
include aicoe-ci configuration file

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,15 @@
+check:
+  - thoth-precommit
+  - thoth-build
+build:
+  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.0"
+  build-stratergy: "Source"
+  registry: "quay.io"
+  registry-org: "thoth-station"
+  registry-project: "qeb-hwt-webhook-receiver"
+  registry-secret: "thoth-station-thoth-pusher-secret"
+deploy:
+  project-org: "thoth-station"
+  project-name: "thoth-application"
+  image-name: "qeb-hwt-webhook-receiver"
+  overlay-contextpath: "qeb-hwt-github-app/overlays/test/imagestreamtag.yaml"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+labels: bug
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels: enhancement
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/major-release.md
+++ b/.github/ISSUE_TEMPLATE/major-release.md
@@ -1,0 +1,11 @@
+---
+name: Major release
+about: Create a new major release
+title: New major release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new major release, please.

--- a/.github/ISSUE_TEMPLATE/minor-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-release.md
@@ -1,0 +1,11 @@
+---
+name: Minor release
+about: Create a new minor release
+title: New minor release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new minor release, please.

--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -1,0 +1,11 @@
+---
+name: Patch release
+about: Create a new patch release
+title: New patch release
+assignees: 'sesheta'
+labels: bot
+---
+
+Hey, Kebechet!
+
+Create a new patch release, please.


### PR DESCRIPTION
include aicoe-ci configuration file
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

#68 

## This introduces a breaking change
- [x] No

## This Pull Request implements

This would allow ci to build image for the application with ubi8-py38 Thoth image and push it to quay.io.

## Description

aicoe-ci.yaml file works as configuration file for the ci.