### PR TITLE
Use neutral conclusion if dependencies are not found

### DIFF
--- a/app.py
+++ b/app.py
@@ -251,6 +251,9 @@ async def on_thamos_workflow_finished(*, action, base_repo_url, check_run_id, in
                         conclusion = "failure"
                         justification = f"Analysis has encountered errors: {error_msg}."
 
+                        if error_msg == "No direct dependencies found":
+                            conclusion = "neutral"
+
                         if adviser_result["report"]:
                             report = adviser_result["report"]
                             text = "See the report below for more details."


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/qeb-hwt/issues/36#event-3966018389

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add check on error message to use neutral instead of failure. (See fixing issue for more information)
