### PR TITLE
updating pre-commit protocol

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 ---
 repos:
-  - repo: git://github.com/asottile/add-trailing-comma
+  - repo: https://github.com/asottile/add-trailing-comma
     rev: v2.1.0
     hooks:
       - id: add-trailing-comma
 
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: trailing-whitespace
@@ -27,12 +27,12 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 6.0.0
     hooks:
       - id: pydocstyle
 
-  - repo: git://github.com/pre-commit/mirrors-mypy.git
+  - repo: https://github.com/pre-commit/mirrors-mypy.git
     rev: v0.812
     hooks:
       - id: mypy


### PR DESCRIPTION
## Related Issues and Dependencies

Related to: https://github.com/thoth-station/thoth-application/issues/2111

Using unencrypted version of the git protocol has been deprecating. Switching to HTTPS for pre-commit repos.